### PR TITLE
Adding content-safe-area for iPhone X

### DIFF
--- a/deploy/components-map.json
+++ b/deploy/components-map.json
@@ -1,4 +1,44 @@
 {
+  "@theme": {
+    "src": "src/templates/01-base/theme/theme.twig",
+    "dest": "fractal/01-base/theme",
+    "file": "theme.twig"
+  },
+  "@typography": {
+    "src": "src/templates/01-base/typography/typography.twig",
+    "dest": "fractal/01-base/typography",
+    "file": "typography.twig"
+  },
+  "@burger": {
+    "src": "src/templates/02-objects/burger/burger.twig",
+    "dest": "fractal/02-objects/burger",
+    "file": "burger.twig"
+  },
+  "@button": {
+    "src": "src/templates/02-objects/button/button.twig",
+    "dest": "fractal/02-objects/button",
+    "file": "button.twig"
+  },
+  "@footer": {
+    "src": "src/templates/03-global/footer/footer.twig",
+    "dest": "fractal/03-global/footer",
+    "file": "footer.twig"
+  },
+  "@header": {
+    "src": "src/templates/03-global/header/header.twig",
+    "dest": "fractal/03-global/header",
+    "file": "header.twig"
+  },
+  "@menu": {
+    "src": "src/templates/03-global/menu/menu.twig",
+    "dest": "fractal/03-global/menu",
+    "file": "menu.twig"
+  },
+  "@tabs": {
+    "src": "src/templates/04-components/tabs/tabs.twig",
+    "dest": "fractal/04-components/tabs",
+    "file": "tabs.twig"
+  },
   "@teaser": {
     "src": "src/templates/04-components/teaser/teaser.twig",
     "dest": "fractal/04-components/teaser",
@@ -18,6 +58,31 @@
     "src": "src/templates/04-components/teaser/teaser--tits.twig",
     "dest": "fractal/04-components/teaser",
     "file": "teaser--tits.twig"
+  },
+  "@box": {
+    "src": "src/templates/05-layouts/_box/_box.twig",
+    "dest": "fractal/05-layouts/_box",
+    "file": "box.twig"
+  },
+  "@feed-grid": {
+    "src": "src/templates/05-layouts/feed-grid/feed-grid.twig",
+    "dest": "fractal/05-layouts/feed-grid",
+    "file": "feed-grid.twig"
+  },
+  "@grid": {
+    "src": "src/templates/06-pages/grid/grid.twig",
+    "dest": "fractal/06-pages/grid",
+    "file": "grid.twig"
+  },
+  "@home": {
+    "src": "src/templates/06-pages/home/home.twig",
+    "dest": "fractal/06-pages/home",
+    "file": "home.twig"
+  },
+  "@wrapper": {
+    "src": "src/templates/06-pages/_wrapper.twig",
+    "dest": "fractal/06-pages",
+    "file": "wrapper.twig"
   },
   "@layout": {
     "src": "src/templates/wrapper/_layout.twig",

--- a/src/scss/_config/_colors.scss
+++ b/src/scss/_config/_colors.scss
@@ -11,5 +11,8 @@ $colors: (
     brand: #a70e0a,
     neutral: #e7e6e0,
     amazon: #fcb12a
+  ),
+  bg: (
+    base: #f9f5ef
   )
 );

--- a/src/scss/framework/_grid.scss
+++ b/src/scss/framework/_grid.scss
@@ -1,3 +1,14 @@
+/*
+	[1] Webkit constant for iOS 11, to account for iPhone X:
+	https://webkit.org/blog/7929/designing-websites-for-iphone-x/
+*/
+.wrapper {
+	padding: constant(safe-area-inset-top)
+						constant(safe-area-inset-right)
+						constant(safe-area-inset-bottom)
+						constant(safe-area-inset-left); // [1]
+}
+
 .g-row {
 	margin-bottom: vr(8, $units: true);
 

--- a/src/scss/framework/_index.scss
+++ b/src/scss/framework/_index.scss
@@ -4,6 +4,14 @@
 	box-sizing: border-box;
 }
 
+/*
+	[1] Set a base background color to avoid white bars in landscape mode on iPhone X.
+			'constant(safe-area-inset-*)' should also be added to elements that bleed to edge of viewport.
+*/
+body {
+	background-color: c(bg, base); // [1]
+}
+
 img {
 	display: block;
 	max-width: 100%;

--- a/src/templates/06-pages/grid/grid.twig
+++ b/src/templates/06-pages/grid/grid.twig
@@ -1,23 +1,25 @@
-<div class="g">
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-	<div class="g__col">GRID ITEM</div>
-</div>
+<div class="wrapper">
+	<div class="g">
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+		<div class="g__col">GRID ITEM</div>
+	</div>
 
 
-<div class="g">
-	<div class="b__col">GRID ITEM</div>
-	<div class="b__col">GRID ITEM</div>
-	<div class="b__col">GRID ITEM</div>
-	<div class="b__col">GRID ITEM</div>
-	<div class="b__col b__col--2">GRID ITEM</div>
+	<div class="g">
+		<div class="b__col">GRID ITEM</div>
+		<div class="b__col">GRID ITEM</div>
+		<div class="b__col">GRID ITEM</div>
+		<div class="b__col">GRID ITEM</div>
+		<div class="b__col b__col--2">GRID ITEM</div>
+	</div>
 </div>

--- a/src/templates/wrapper/_layout.twig
+++ b/src/templates/wrapper/_layout.twig
@@ -6,7 +6,7 @@
 	  <meta charset="utf-8">
     <title>{{ siteTitle|length ? siteTitle : 'Mud/Fractal' }}</title>
 	  <meta name="description" content="">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1" viewport-fit="cover">
 		<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -28,7 +28,7 @@
 	      document.createElement('picture');
 	      loadJS("/dist/js/picturefill.min.js");
 	    }
-	  </script>	
+	  </script>
   </head>
 
   <body>

--- a/src/tokens/colors.json
+++ b/src/tokens/colors.json
@@ -11,5 +11,8 @@
 		"brand": "#a70e0a",
 		"neutral": "#e7e6e0",
 		"amazon": "#fcb12a"
-	}
+	},
+  "bg": {
+    "base": "#f9f5ef"
+  }
 }


### PR DESCRIPTION
Adding `viewport-fit="cover"` to viewport meta tag and content-safe-area on `.wrapper` to account for iOS in landscape mode.