### PR TITLE
Adding format detection meta tag to <head>

### DIFF
--- a/deploy/templates/wrapper/_layout.twig
+++ b/deploy/templates/wrapper/_layout.twig
@@ -16,6 +16,7 @@
 		<link rel="manifest" href="/manifest.json">
 		<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#cb1d18">
 		<meta name="theme-color" content="#cb1d18">
+		<meta content="telephone=no" name="format-detection">
 	  <script>var html=document.getElementsByTagName("html")[0];html.classList?html.classList.remove("no-js"):html.className=el.className.replace(new RegExp("(^|\\b)"+className.split(" ").join("|")+"(\\b|$)","gi")," ");</script>
 		{% if stamp != '' %}
 			{% block critical_css %}

--- a/src/templates/wrapper/_base.twig
+++ b/src/templates/wrapper/_base.twig
@@ -17,6 +17,7 @@
 			<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#671eb8">
 			<meta name="msapplication-TileColor" content="#671eb8">
 			<meta name="theme-color" content="#671eb8">
+			<meta content="telephone=no" name="format-detection">
 			<script>var html=document.getElementsByTagName("html")[0];html.classList?html.classList.remove("no-js"):html.className=el.className.replace(new RegExp("(^|\\b)"+className.split(" ").join("|")+"(\\b|$)","gi")," ");</script>
 		
 			{% if stamp != '' %}


### PR DESCRIPTION
To prevent iOS and other mobile devices automatically converting strings of numbers to links.